### PR TITLE
Skip OpenTelemetry setup when Application Insights connection string is missing

### DIFF
--- a/fanoutfanin/Program.cs
+++ b/fanoutfanin/Program.cs
@@ -10,11 +10,17 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
+#if DEBUG
 if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
 {
     builder.Services.AddOpenTelemetry()
         .UseFunctionsWorkerDefaults()
         .UseAzureMonitorExporter();
 }
+#else
+builder.Services.AddOpenTelemetry()
+    .UseFunctionsWorkerDefaults()
+    .UseAzureMonitorExporter();
+#endif
 
 builder.Build().Run();

--- a/fanoutfanin/Program.cs
+++ b/fanoutfanin/Program.cs
@@ -10,8 +10,11 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-builder.Services.AddOpenTelemetry()
-    .UseFunctionsWorkerDefaults()
-    .UseAzureMonitorExporter();
+if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
+{
+    builder.Services.AddOpenTelemetry()
+        .UseFunctionsWorkerDefaults()
+        .UseAzureMonitorExporter();
+}
 
 builder.Build().Run();


### PR DESCRIPTION
Guards the OpenTelemetry/Azure Monitor exporter setup so the app starts cleanly when running locally without an `APPLICATIONINSIGHTS_CONNECTION_STRING` configured.